### PR TITLE
Update CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-turing.ml
+turinglang.org


### PR DESCRIPTION
I believe that if we make this change we should be able to automatically redirect people to the new site, turinglang.org. I'm not positive that this will work but it's worth a shot!