### PR TITLE
added Changelog page and link in navbar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 
 /.quarto/
 _site/
+changelog.qmd

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -4,6 +4,7 @@ project:
     # Change port if it's busy in your system or just remove this line so that It will automatically use any free port
     port: 4200
     browser: true
+  pre-render: sh assets/scripts/changelog.sh
 
 # These cannot be used as variables. They are reserved for the project configuration.
 website:
@@ -16,7 +17,7 @@ website:
     type: overlay
   navbar:
     logo: "assets/images/turing-logo.svg"
-    logo-href: https://turinglang.org/
+    # logo-href: https://turinglang.org/
     background: "#073c44"
     foreground: "#ffffff"
     left:
@@ -37,6 +38,8 @@ website:
       - icon: github
         href: https://github.com/TuringLang/Turing.jl
         text: Turing GitHub
+      - icon: file-earmark-diff
+        href: changelog.qmd
   
   page-footer:
     background: "#073c44"

--- a/assets/scripts/changelog.sh
+++ b/assets/scripts/changelog.sh
@@ -1,0 +1,12 @@
+url="https://raw.githubusercontent.com/TuringLang/Turing.jl/master/HISTORY.md"
+
+changelog_content=$(curl -s "$url")
+
+cat << EOF > changelog.qmd
+---
+title: Changelog
+repo-actions: false
+---
+
+$changelog_content
+EOF


### PR DESCRIPTION
If it's fine then I can add it in docs repo too!

Closes #72 

it looks like this in navigation bar and this is the best icon I found for changelog:
![Screenshot 2024-06-08 130239](https://github.com/TuringLang/turinglang.github.io/assets/123811742/40785064-7aab-4bb6-92be-7ab90e0b9e88)
