### PR TITLE
added versions dropdown in this repo too

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -30,6 +30,14 @@ website:
         text: News
       - href: team/
         text: Team
+    right:
+      # Current version
+      - text: "v0.33"
+        menu:
+          - text: Changelog
+            href: https://turinglang.org/docs/changelog.html
+          - text: All Versions
+            href: https://turinglang.org/docs/versions.html
     tools:
       - icon: twitter
         href: https://x.com/TuringLang

--- a/theming/styles.css
+++ b/theming/styles.css
@@ -43,3 +43,11 @@
     display: flex;
     justify-content: center;
 }
+
+.dropdown-menu {
+    text-align: center;
+    min-width: 100px !important;
+    border-radius: 5px;
+    max-height: 250px;
+    overflow: scroll;
+}


### PR DESCRIPTION
I do not know if it's necessary or not, we will need to manually update it every time when new Turing version is released! We can automate this using pre-render script but still we will need to trigger the workflow manually every time, so I thought it's better to update version manually then depend on pre-render script! 