### PR TITLE
Add WebSite structured data so that site title shows up in Google

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -68,6 +68,17 @@ format:
     smooth-scroll: true
     code-overflow: wrap
     output-block-background: true
+    include-in-header:
+      - text: |
+          <script type="application/ld+json">
+          {
+            "@context" : "https://schema.org",
+            "@type" : "WebSite",
+            "name" : "Turing.jl",
+            "alternateName": "The Turing Language",
+            "url" : "https://turinglang.org/",
+          }
+          </script>
 
 # Global Variables to use in any qmd files using:
 # {{< meta site-url >}}


### PR DESCRIPTION
Closes #108 (I _think_, also I suppose Google will need to reindex the site, see https://developers.google.com/search/docs/crawling-indexing/ask-google-to-recrawl).

Note, I suspect we're running into this problem (emphasis mine, quoted from https://developers.google.com/search/docs/appearance/site-names):

> Provide an alternative name. While our site name system tries to use your preferred site name, sometimes the name isn't available for use. **For example, our system generally won't use the same site name for two different sites that are global in nature.** In other cases, our system might determine that a site is more commonly recognized by an acronym than by a full name. Providing an alternative name using the alternateName property allows Google to consider other options if your preferred choice isn't selected. 

Thus, the original `<title>` tag of `Turing.jl` isn't being picked up by Google, because the `turing.ml` domain already took that site title. I added an `alternateName` of `The Turing Language` to try to get around that.